### PR TITLE
save branch options using rlang::expr_text() instead of rlang::expr_n…

### DIFF
--- a/R/branch.R
+++ b/R/branch.R
@@ -123,7 +123,7 @@ reset_parameters <- function(.mverse) {
 
 as_option_list <- function(x) {
   opts <- sapply(
-    x$opts, function(s) stringr::str_replace(rlang::expr_name(s), "^~", ""))
+    x$opts, function(s) stringr::str_replace(rlang::expr_text(s), "^~", ""))
   if(!is.null(x$name))
     opts <- stats::setNames(opts, paste0(x$name, "_", 1:length(opts)))
   return(opts)

--- a/R/condition.R
+++ b/R/condition.R
@@ -24,8 +24,8 @@
 #' @family {methods for working with a branch condition}
 #' @export
 branch_condition <- function(x, y, reject = FALSE) {
-  x <- stringr::str_replace(rlang::expr_name(rlang::enquo(x)), "^~", "")
-  y <- stringr::str_replace(rlang::expr_name(rlang::enquo(y)), "^~", "")
+  x <- stringr::str_replace(rlang::expr_text(rlang::enquo(x)), "^~", "")
+  y <- stringr::str_replace(rlang::expr_text(rlang::enquo(y)), "^~", "")
   if (any(stringr::str_starts(c(x, y), "\"")))
     stop(
       'You must provide the options as expressions not strings.',


### PR DESCRIPTION
save branch options using `rlang::expr_text()` instead of `rlang::expr_name()` in branches_list attribute